### PR TITLE
Fixes for multiple classes on a html attribute and whitespace support

### DIFF
--- a/dist/lib/jssoup.js
+++ b/dist/lib/jssoup.js
@@ -17,7 +17,6 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 var htmlparser = require('htmlparser');
 if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
   try {
-    console.log(navigator.platform);
     htmlparser = Tautologistics.NodeHtmlParser;
   } catch (e) {}
 } else {
@@ -345,21 +344,6 @@ var SoupTag = function (_SoupElement3) {
     get: function get() {
       return this.getText();
     }
-
-    //* descendants () {
-    //var cur = this.nextElement;
-    //while (cur) {
-    //var parent = cur.parent;
-    //while (parent && parent != this) {
-    //parent = parent.parent;
-    //}
-    //if (!parent) break;
-    //yield cur;
-    //cur = cur.nextElement;
-    //}
-    //return undefined;
-    //}
-
   }, {
     key: 'descendants',
     get: function get() {
@@ -421,8 +405,17 @@ var SoupStrainer = function () {
   function SoupStrainer(name, attrs, string) {
     _classCallCheck(this, SoupStrainer);
 
-    if (typeof attrs == 'string' || Array.isArray(attrs)) {
+    if (typeof attrs == 'string') {
+      attrs = { class: [attrs] };
+    } else if (Array.isArray(attrs)) {
       attrs = { class: attrs };
+    } else if (attrs && attrs.class && typeof attrs.class == 'string') {
+      attrs.class = [attrs.class];
+    }
+    if (attrs && attrs.class) {
+      for (var i = 0; i < attrs.class.length; ++i) {
+        attrs.class[i] = attrs.class[i].trim();
+      }
     }
     this.name = name;
     this.attrs = attrs;
@@ -451,7 +444,7 @@ var SoupStrainer = function () {
           var props = Object.getOwnPropertyNames(this.attrs);
           var found = false;
           for (var i = 0; i < props.length; ++i) {
-            if (props[i] in tag.attrs && this._matchAttrs(tag.attrs[props[i]], this.attrs[props[i]])) {
+            if (props[i] in tag.attrs && this._matchAttrs(props[i], tag.attrs[props[i]], this.attrs[props[i]])) {
               found = true;
               break;
             }
@@ -477,15 +470,19 @@ var SoupStrainer = function () {
     }
   }, {
     key: '_matchAttrs',
-    value: function _matchAttrs(candidateAttrs, attrs) {
+    value: function _matchAttrs(name, candidateAttrs, attrs) {
+      if (typeof candidateAttrs == 'string') {
+        if (name == 'class') {
+          candidateAttrs = candidateAttrs.replace(/\s\s+/g, ' ').trim().split(' ');
+        } else {
+          candidateAttrs = [candidateAttrs];
+        }
+      }
       if (typeof attrs == 'string') {
         attrs = [attrs];
       }
-      if (typeof candidateAttrs == 'string') {
-        candidateAttrs = [candidateAttrs];
-      }
-      for (var i = 0; i < candidateAttrs.length; ++i) {
-        if (attrs.indexOf(candidateAttrs[i]) < 0) return false;
+      for (var i = 0; i < attrs.length; ++i) {
+        if (candidateAttrs.indexOf(attrs[i]) < 0) return false;
       }
       return true;
     }

--- a/lib/jssoup.js
+++ b/lib/jssoup.js
@@ -14,7 +14,7 @@ class SoupElement {
     this.previousElement = previousElement;
     this.nextElement = nextElement;
   }
-  
+
   get nextSibling () {
     if (!this.parent) return undefined;
     var index = this.parent.contents.indexOf(this);
@@ -28,7 +28,7 @@ class SoupElement {
     if (index == 0) return undefined;
     return this.parent.contents[index - 1];
   }
-  
+
   // remove item from dom tree
   extract() {
     var extractFirst = this;
@@ -64,18 +64,18 @@ class SoupComment extends SoupElement{
   constructor(text, parent=null, previousElement=null, nextElement=null) {
     super(parent, previousElement, nextElement);
     this._text = text;
-  }  
+  }
 }
 
 class SoupString extends SoupElement{
   constructor(text, parent=null, previousElement=null, nextElement=null) {
     super(parent, previousElement, nextElement);
-    this._text = text; 
+    this._text = text;
   }
 }
 
 SoupString.prototype.toString = function() {
-	return this._text;
+  return this._text;
 }
 
 class SoupTag extends SoupElement{
@@ -96,7 +96,7 @@ class SoupTag extends SoupElement{
    */
   _build(children) {
     if (!children || children.length < 1) return this;
-    var last = this; 
+    var last = this;
     for (var i = 0; i < children.length; ++i) {
       var ele = this._transfer(children[i]);
       last.nextElement = ele;
@@ -107,7 +107,7 @@ class SoupTag extends SoupElement{
         last = ele;
       }
       this._append(ele);
-    }   
+    }
     return last;
   }
 
@@ -147,7 +147,7 @@ class SoupTag extends SoupElement{
   findAll (name=undefined, attrs=undefined, string=undefined) {
     var results = [];
     var strainer = new SoupStrainer(name, attrs, string);
-    
+
     var descendants = this.descendants;
     for (var i = 0; i < descendants.length; ++i) {
       if (descendants[i] instanceof SoupTag) {
@@ -167,27 +167,13 @@ class SoupTag extends SoupElement{
       if (descendants[i] instanceof SoupString) {
         text.push(descendants[i]._text);
       }
-    } 
+    }
     return text.join(separator);
   }
 
   get text() {
     return this.getText();
   }
-
-  //* descendants () {
-    //var cur = this.nextElement;
-    //while (cur) {
-      //var parent = cur.parent;
-      //while (parent && parent != this) {
-        //parent = parent.parent;
-      //}
-      //if (!parent) break;
-      //yield cur;
-      //cur = cur.nextElement;
-    //}
-    //return undefined;
-  //}
 
   get descendants() {
     var ret = [];
@@ -220,7 +206,7 @@ class SoupTag extends SoupElement{
 
   _prettify(indent, breakline, level=0) {
     var text = '';
-    var attrs = this._convertAttrsToString(); 
+    var attrs = this._convertAttrsToString();
     if (attrs) {
       text += indent.repeat(level) + '<' + this.name + ' ' + attrs + '>' + breakline;
     } else {
@@ -241,7 +227,7 @@ class SoupTag extends SoupElement{
   prettify(indent=' ', breakline='\n') {
     return this._prettify(indent, breakline).trim();
   }
-  
+
   /*
    * Append item in contents
    */
@@ -279,7 +265,7 @@ class SoupTag extends SoupElement{
 }
 
 SoupTag.prototype.toString = function() {
-  return this.prettify('', ''); 
+  return this.prettify('', '');
 }
 
 const ROOT_TAG_NAME = '[document]';
@@ -297,17 +283,26 @@ export default class JSSoup extends SoupTag{
     parser.parseComplete(text);
 
     if (Array.isArray(handler.dom)) {
-      this._build(handler.dom); 
+      this._build(handler.dom);
     } else {
-      this._build([handler.dom]); 
+      this._build([handler.dom]);
     }
   }
 }
 
 class SoupStrainer {
   constructor(name, attrs, string) {
-    if (typeof attrs == 'string' || Array.isArray(attrs)) {
+    if (typeof attrs == 'string') {
+      attrs = {class: [attrs]};
+    } else if (Array.isArray(attrs)) {
       attrs = {class: attrs};
+    } else if (attrs && attrs.class && typeof attrs.class == 'string') {
+      attrs.class = [attrs.class];
+    }
+    if (attrs && attrs.class) {
+      for (var i = 0; i < attrs.class.length; ++i) {
+        attrs.class[i] = attrs.class[i].trim();
+      }
     }
     this.name = name;
     this.attrs = attrs;
@@ -321,7 +316,7 @@ class SoupStrainer {
         if (this._matchName(tag.string, this.string))
           return tag.string;
         else
-          return null; 
+          return null;
       }
       return tag;
     }
@@ -337,15 +332,15 @@ class SoupStrainer {
         var props = Object.getOwnPropertyNames(this.attrs);
         var found = false;
         for (var i = 0; i < props.length; ++i) {
-          if (props[i] in tag.attrs && this._matchAttrs(tag.attrs[props[i]], this.attrs[props[i]])) {
+          if (props[i] in tag.attrs && this._matchAttrs(props[i], tag.attrs[props[i]], this.attrs[props[i]])) {
             found = true;
-            break; 
+            break;
           }
         }
         if (!found) return null;
       }
     }
-    return tag;  
+    return tag;
   }
 
   _matchName(tagItem, name) {
@@ -361,15 +356,19 @@ class SoupStrainer {
     return tagItem == name;
   }
 
-  _matchAttrs(candidateAttrs, attrs) {
+  _matchAttrs(name, candidateAttrs, attrs) {
+    if (typeof candidateAttrs == 'string') {
+      if (name == 'class') {
+        candidateAttrs = candidateAttrs.replace(/\s\s+/g, ' ').trim().split(' ');
+      } else {
+        candidateAttrs = [candidateAttrs];
+      }
+    }
     if (typeof attrs == 'string') {
       attrs = [attrs];
     }
-    if (typeof candidateAttrs == 'string') {
-      candidateAttrs = [candidateAttrs];
-    }
-    for (var i = 0; i < candidateAttrs.length; ++i) {
-      if (attrs.indexOf(candidateAttrs[i]) < 0) 
+    for (var i = 0; i < attrs.length; ++i) {
+      if (candidateAttrs.indexOf(attrs[i]) < 0)
         return false;
     }
     return true;

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,6 @@
 const assert = require('assert');
 import JSSoup from '../lib/jssoup';
 
-
 const data = `
   <html><head><title>The Dormouse's story</title></head>
   <body>
@@ -14,9 +13,21 @@ const data = `
   and they lived at the bottom of a well.</p>
 
   <p class="story">...</p>
+
+  <span class="one">One</span>
+  <span class="two">Two</span>
+  <span class="three">Three</span>
+  <span class="one two three">One Two Three</span>
+
+  <div class=" whitespace">Whitespace Left</div>
+  <div class="whitespace ">Whitespace Right</div>
+  <div class=" whitespace ">Whitespace Left and Right</div>
+  <div class="    so    much    whitespace    ">Whitespace</div>
+
   </body>
   </html>
-`
+`;
+
 describe('contents', function() {
   it('should be OK', function(done) {
     var soup = new JSSoup('<a>hello</a>');
@@ -177,7 +188,7 @@ describe('extract', function() {
     assert.equal(b.parent, null);
     done();
   });
-  
+
   it('should be OK with combine function', function(done) {
     var soup = new JSSoup('<a class="hi">1</a><b>2</b><c>3</c>');
     var a = soup.contents[0];
@@ -203,7 +214,7 @@ describe('findAll', function() {
     assert.equal(ret.length, 1);
     soup = new JSSoup(data);
     ret = soup.findAll();
-    assert.equal(ret.length, 11);
+    assert.equal(ret.length, 19);
     ret = soup.findAll('a');
     assert.equal(ret.length, 3);
     ret = soup.findAll('p');
@@ -212,6 +223,10 @@ describe('findAll', function() {
     assert.equal(ret.length, 1);
     ret = soup.findAll('title');
     assert.equal(ret.length, 1);
+    ret = soup.findAll('span');
+    assert.equal(ret.length, 4);
+    ret = soup.findAll('div');
+    assert.equal(ret.length, 4);
     ret = soup.findAll('');
     assert.equal(ret.length, 0);
     done();
@@ -223,7 +238,7 @@ describe('findAll', function() {
     assert.equal(ret.length, 1);
     assert.equal(ret[0].name, 'a');
     ret = soup.findAll('b');
-    assert.equal(ret.length, 0); 
+    assert.equal(ret.length, 0);
     done();
   });
 
@@ -232,17 +247,14 @@ describe('findAll', function() {
     var ret = soup.findAll(undefined, undefined, 'hello');
     assert.equal(ret.length, 1);
     assert.equal(ret[0].constructor.name, 'SoupString');
-
     ret = soup.findAll('a', undefined, 'hello');
     assert.equal(ret.length, 1);
     assert.equal(ret[0].string, 'hello');
     assert.equal(ret[0].name, 'a');
-
     soup = new JSSoup(data);
     ret = soup.findAll(undefined, undefined, '...');
     assert.equal(ret.length, 1);
     assert.equal(ret[0], '...');
-
     ret = soup.findAll('p', undefined, '...');
     assert.equal(ret.length, 1);
     assert.equal(ret[0].name, 'p');
@@ -254,14 +266,63 @@ describe('findAll', function() {
     var soup = new JSSoup(data);
     var ret = soup.findAll('p', 'title');
     assert.equal(ret.length, 1);
-    assert.equal(ret[0].name, 'p')
+    assert.equal(ret[0].name, 'p');
     var ret2 = soup.findAll('p', {class: 'title'});
     assert.equal(ret2.length, 1);
-    assert.equal(ret[0], ret2[0])
+    assert.equal(ret[0], ret2[0]);
     ret = soup.findAll('p', 'story');
     assert.equal(ret.length, 2);
     done();
   });
+
+  it('should be OK with multiple classes', function(done) {
+    var soup = new JSSoup(data);
+    var ret = soup.findAll('span', 'one');
+    assert.equal(ret.length, 2);
+    assert.equal(ret[0].name, 'span');
+    var ret2 = soup.findAll('span', 'two');
+    assert.equal(ret2.length, 2);
+    assert.equal(ret2[0].name, 'span');
+    var ret3 = soup.findAll('span', 'three');
+    assert.equal(ret3.length, 2);
+    assert.equal(ret3[0].name, 'span');
+    done();
+  });
+
+  it('should be OK with whitespace in class definition', function(done) {
+    var soup = new JSSoup(data);
+    var ret = soup.findAll('div', 'whitespace');
+    assert.equal(ret.length, 4);
+    assert.equal(ret[0].name, 'div');
+    var ret2 = soup.findAll('div', ['whitespace']);
+    assert.equal(ret2.length, 4);
+    assert.equal(ret2[0].name, 'div');
+    var ret3 = soup.findAll('div', {class: 'whitespace'});
+    assert.equal(ret3.length, 4);
+    assert.equal(ret3[0].name, 'div');
+    var ret4 = soup.findAll('div', {class: ['whitespace']});
+    assert.equal(ret4.length, 4);
+    assert.equal(ret4[0].name, 'div');
+    done();
+  });
+
+  it('should be OK with whitespace in class selector', function(done) {
+    var soup = new JSSoup(data);
+    var ret = soup.findAll('div', 'whitespace ');
+    assert.equal(ret.length, 4);
+    assert.equal(ret[0].name, 'div');
+    var ret2 = soup.findAll('div', ['whitespace ']);
+    assert.equal(ret2.length, 4);
+    assert.equal(ret2[0].name, 'div');
+    var ret3 = soup.findAll('div', {class: 'whitespace '});
+    assert.equal(ret3.length, 4);
+    assert.equal(ret3[0].name, 'div');
+    var ret4 = soup.findAll('div', {class: ['whitespace ']});
+    assert.equal(ret4.length, 4);
+    assert.equal(ret4[0].name, 'div');
+    done();
+  });
+
 });
 
 describe('prev next', function() {
@@ -280,36 +341,16 @@ describe('prev next', function() {
   });
 });
 
-//describe('*descendants', function() {
-  //it('should be OK', function(done) {
-    //var soup = new JSSoup(data);
-    //assert.equal(soup.descendants.length, 0);
-    //var cur = soup.nextElement;
-    //for (let i of soup.descendants()) {
-      //assert.equal(i, cur);
-      //cur = cur.nextElement;
-    //} 
-    //done();
-  //});
-
-  //it('should be OK', function(done) {
-    //var soup = new JSSoup('<div><a></a><b></b></div>');
-    //var a = soup.nextElement.nextElement;
-    //assert.equal(a.descendants.length, 0);
-    //done();
-  //});
-//});
-
 describe('descendants', function() {
   it('should be OK', function(done) {
     var soup = new JSSoup(data);
     assert.notEqual(soup.descendants, soup.descendants);
-    assert.equal(soup.descendants.length, 21);
+    assert.equal(soup.descendants.length, 37);
     var cur = soup.nextElement;
     for (let i of soup.descendants) {
       assert.equal(i, cur);
       cur = cur.nextElement;
-    } 
+    }
     done();
   });
 


### PR DESCRIPTION
### Multiple classes

These changes enable JSSoup to locate elements by `class` with `findAll` even when the element has multiple classes defined, for example:

```
<span class="one">One</span>
<span class="two">Two</span>
<span class="three">Three</span>
<span class="one two three">One Two Three</span>
```

Previously:
- `findAll('span', 'one')` would not have found the last span
- `findAll('span', 'two')` would not have found the last span
- `findAll('span', 'three')` would not have found the last span

---

### Whitespace in class attribute

These changes also enable JSSoup to locate elements by `class` with `findAll` even when the element `class` contains whitespace (as is often the case in generated pages), for example:

```
<div class=" whitespace">Whitespace Left</div>
<div class="whitespace ">Whitespace Right</div>
<div class=" whitespace ">Whitespace Left and Right</div>
<div class="    so    much    whitespace    ">Whitespace</div>
```

Previously:
- `findAll('div', 'whitespace')` would not have found any of the above divs

---

### Whitespace in class selector

These change also enable JSSoup to locate elements by `class` with `findAll` even when the selector provided contains whitespace, for example:

```
findAll('div', ' whitespace ');
or
findAll('div', { class: ' whitespace ' });
```

Previously:
- This would have found only the 3rd div (as it was effectively an "exact match")

---

### Testing

New tests have been added to confirm the expected behaviour.

All previous tests are still passing.
