### PR TITLE
Fixed: jssoup can not parser html with '<!DOCTYPE html PUBLIC "-//W3C…

### DIFF
--- a/dist/lib/jssoup.js
+++ b/dist/lib/jssoup.js
@@ -393,7 +393,7 @@ var SoupTag = function (_SoupElement3) {
         while (parent && parent != this) {
           parent = parent.parent;
         }
-        if (!parent) break;
+        // if (!parent) break;
         ret.push(cur);
         cur = cur.nextElement;
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jssoup",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1093,12 +1093,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1113,17 +1115,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1240,7 +1245,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1252,6 +1258,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1266,6 +1273,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1273,12 +1281,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1297,6 +1307,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1377,7 +1388,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1389,6 +1401,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1510,6 +1523,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/test/node-test.js
+++ b/test/node-test.js
@@ -1,0 +1,14 @@
+const JSSoup = require('../dist/lib/jssoup').default
+
+const data = `
+  <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+  <html><head><title>The Dormouse's story</title></head>
+  <body>
+  <div class="one">One</div>
+  </body>
+  </html>
+`
+
+var soup = new JSSoup(data)
+var tag = soup.find('div', {'class': 'one'})
+console.log(tag.text)

--- a/test/test.js
+++ b/test/test.js
@@ -2,6 +2,7 @@ const assert = require('assert');
 import JSSoup from '../lib/jssoup';
 
 const data = `
+  <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
   <html><head><title>The Dormouse's story</title></head>
   <body>
   <p class="title"><b>The Dormouse's story</b></p>


### PR DESCRIPTION
Html content like

```
<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
<html><head><title>The Dormouse's story</title></head>
<body>
<div class="one">One</div>
</body>
</html>
```

can not be parser.

The first element's parent attribute is null so the loop will break. So delete `if (!parent) break;` seem worked.

But I don't know the mechanism, may be it's parent should be `[document]`.